### PR TITLE
Pirate Galleons and Fist Anger Issues

### DIFF
--- a/nsv13/code/modules/overmap/types/spacepirates.dm
+++ b/nsv13/code/modules/overmap/types/spacepirates.dm
@@ -153,3 +153,47 @@
 	weapon_types[FIRE_MODE_GAUSS] = new /datum/ship_weapon/gauss(src)
 	weapon_types[FIRE_MODE_PDC] = new /datum/ship_weapon/pdc_mount(src)
 	flak_battery_amount = 2
+
+/obj/structure/overmap/spacepirate/ai/cruiser // to all of you who kept building guns on the roci, the pirates did it first.
+	name = "Space Pirate Galleon"
+	desc = "Sleepin' in the cold below."
+	icon = 'nsv/icons/overmap/hephaistus.dmi'
+	icon_state = "mining_cruiser"
+	mass = MASS_LARGE
+	sprite_spize = 128
+	damage_states = FALSE
+	bound_width = 128
+	bound_height = 128
+	obj_integrity = 1000
+	max_integrity = 1000
+	integrity_failure = 1000
+	armor = list("overmap_light" = 85, "overmap_medium" = 55 "overmap_heavy" = 25
+	ai_flags = AI_FLAG_BATTLESHIP
+	combat_dice_type = /datum/combat_dice/battleship
+
+/obj/structure/overmap/spacepirate/ai/cruiser/apply_weapons()
+	var/random_weapons = pick(1, 2, 3)
+	switch(random_weapons)
+
+if(1)
+	name = "Space Pirate Assault Galleon"
+	weapon_types[FIRE_MODE_RAILGUN] = new /datum/ship_weapon/railgun(src)
+	weapon_types[FIRE_MODE_GAUSS] = new /datum/ship_weapon/quadgauss(src)
+	weapon_types[FIRE_MODE_PDC] = new /datum/ship_weapon/pdc_mount(src)
+	weapon_types[FIRE_MODE_ANTI_AIR] = new /datum/ship_weapon/aa_guns(src)
+	shots_left = 44
+if(2)
+	name = "Space Pirate Ordinance Galleon"
+	weapon_types[FIRE_MODE_TORPEDO] = new /datum/ship_weapon/torpedo_launcher(src)
+	weapon_types[FIRE_MODE_MISSILE} = new /datum/ship_weapon/missile_launcher(src)
+	weapon_types[FIRE_MODE_GAUSS] = new /datum/ship_weapon/gauss(src)
+	weapon_types[FIRE_MODE_PDC] = new /datum/ship_weapon/pdc_mount(src)
+	torpedoes = 16
+	missiles = 16
+if(3)
+	name = "Space Pirate Flak Galleon"
+	weapon_types[FIRE_MODE_ANTI_AIR] = new /datum/ship_weapon/aa_guns(src)
+	weapon_types[FIRE_MODE_GAUSS] = new /datum/ship_weapon/gauss(src)
+	weapon_types[FIRE_MODE_FLAK] = new /datum/ship_weapon/flak(src)
+	flak_battery_amount = 4
+	

--- a/nsv13/code/modules/overmap/types/syndicate.dm
+++ b/nsv13/code/modules/overmap/types/syndicate.dm
@@ -451,7 +451,8 @@
 	ai_controlled = TRUE
 	shots_left = 500
 	missiles = 30
-	ai_flags = AI_FLAG_ELITE | AI_FLAG_BATTLESHIP
+	ai_behavior = AI_AGRESSIVE
+	ai_flags = AI_FLAG_ELITE | AI_FLAG_BATTLESHIP | AI_FLAG_SWARMER
 	can_resupply = TRUE
 	combat_dice_type = /datum/combat_dice/battleship
 	ai_can_launch_fighters = TRUE //AI variable. Allows your ai ships to spawn fighter craft


### PR DESCRIPTION
## About The Pull Request
Using code bastardised from earlier space pirates, adds a step above the gunship and a step below the dreadnaught, the galleon. There's three varied load-outs for each vessel. 
One Assault, One Flak and One Ordinance
## Why It's Good For The Game
Wires Bad, Raycon Good.
Variety good, stagnation bad.
## Changelog
:cl:
add: Galleons for Space Pirates, armaments chosen at random.
tweak: Changes to Fist AI
/:cl:
